### PR TITLE
Allow `null` for `util.inspect`, expose deprecated `vm.createScript`

### DIFF
--- a/0.10/node.d.ts
+++ b/0.10/node.d.ts
@@ -1337,7 +1337,7 @@ declare module "stream" {
 declare module "util" {
     export interface InspectOptions {
         showHidden?: boolean;
-        depth?: number;
+        depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
     }
@@ -1348,7 +1348,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
@@ -1439,6 +1439,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/0.11/node.d.ts
+++ b/0.11/node.d.ts
@@ -1298,7 +1298,7 @@ declare module "stream" {
 declare module "util" {
     export interface InspectOptions {
         showHidden?: boolean;
-        depth?: number;
+        depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
     }
@@ -1306,7 +1306,7 @@ declare module "util" {
     export function format(format: any, ...param: any[]): string;
     export function deprecate(fn: Function, msg: string): Function;
     export function debuglog(set: string): Function;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isBoolean(arg: any): boolean;
@@ -1415,6 +1415,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/0.12/node.d.ts
+++ b/0.12/node.d.ts
@@ -904,14 +904,17 @@ declare module "readline" {
 }
 
 declare module "vm" {
-    export interface Context { }
-    export interface Script {
+    export interface Context {}
+
+    export class Script {
+        constructor (code: string, filename?: string);
         runInThisContext(): void;
         runInNewContext(sandbox?: Context): void;
     }
+
     export function runInThisContext(code: string, filename?: string): void;
     export function runInNewContext(code: string, sandbox?: Context, filename?: string): void;
-    export function runInContext(code: string, context: Context, filename?: string): void;
+    export function runInContext(code: string, context: Context, filename?: string): any;
     export function createContext(initSandbox?: Context): Context;
     export function createScript(code: string, filename?: string): Script;
 }
@@ -1849,7 +1852,7 @@ declare module "stream" {
 declare module "util" {
     export interface InspectOptions {
         showHidden?: boolean;
-        depth?: number;
+        depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
     }
@@ -1860,7 +1863,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
@@ -2176,6 +2179,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/0.8/node.d.ts
+++ b/0.8/node.d.ts
@@ -1131,7 +1131,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): void;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): void;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
     export function isDate(object: any): boolean;
@@ -1195,6 +1195,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/4/node.d.ts
+++ b/4/node.d.ts
@@ -1149,7 +1149,8 @@ declare module "readline" {
 }
 
 declare module "vm" {
-    export interface Context { }
+    export interface Context {}
+
     export interface ScriptOptions {
         filename?: string;
         lineOffset?: number;
@@ -1159,6 +1160,7 @@ declare module "vm" {
         cachedData?: Buffer;
         produceCachedData?: boolean;
     }
+
     export interface RunningScriptOptions {
         filename?: string;
         lineOffset?: number;
@@ -1166,18 +1168,24 @@ declare module "vm" {
         displayErrors?: boolean;
         timeout?: number;
     }
+
     export class Script {
         constructor(code: string, options?: ScriptOptions);
         runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
     }
+
     export function createContext(sandbox?: Context): Context;
     export function isContext(sandbox: Context): boolean;
     export function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions): any;
     export function runInDebugContext(code: string): any;
     export function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions): any;
     export function runInThisContext(code: string, options?: RunningScriptOptions): any;
+    /**
+     * @deprecated
+     */
+    export function createScript(code: string, filename?: string): Script;
 }
 
 declare module "child_process" {
@@ -2236,7 +2244,7 @@ declare module "stream" {
 declare module "util" {
     export interface InspectOptions {
         showHidden?: boolean;
-        depth?: number;
+        depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
     }
@@ -2247,7 +2255,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
@@ -2567,6 +2575,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/6/node.d.ts
+++ b/6/node.d.ts
@@ -1166,6 +1166,7 @@ declare module "readline" {
 
 declare module "vm" {
     export interface Context { }
+
     export interface ScriptOptions {
         filename?: string;
         lineOffset?: number;
@@ -1175,25 +1176,36 @@ declare module "vm" {
         cachedData?: Buffer;
         produceCachedData?: boolean;
     }
-    export interface RunningScriptOptions {
+
+    export interface RunInNewContextOptions {
         filename?: string;
         lineOffset?: number;
         columnOffset?: number;
         displayErrors?: boolean;
         timeout?: number;
     }
+
+    export interface RunInContextOptions extends RunInNewContextOptions {
+        breakOnSigint?: boolean;
+    }
+
     export class Script {
         constructor(code: string, options?: ScriptOptions);
-        runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
-        runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
-        runInThisContext(options?: RunningScriptOptions): any;
+        runInContext(contextifiedSandbox: Context, options?: RunInContextOptions): any;
+        runInNewContext(sandbox?: Context, options?: RunInNewContextOptions): any;
+        runInThisContext(options?: RunInNewContextOptions): any;
     }
+
     export function createContext(sandbox?: Context): Context;
     export function isContext(sandbox: Context): boolean;
-    export function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions): any;
+    export function runInContext(code: string, contextifiedSandbox: Context, options?: RunInNewContextOptions): any;
     export function runInDebugContext(code: string): any;
-    export function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions): any;
-    export function runInThisContext(code: string, options?: RunningScriptOptions): any;
+    export function runInNewContext(code: string, sandbox?: Context, options?: RunInNewContextOptions): any;
+    export function runInThisContext(code: string, options?: RunInNewContextOptions): any;
+    /**
+     * @deprecated
+     */
+    export function createScript(code: string, filename?: string): Script;
 }
 
 declare module "child_process" {
@@ -2252,7 +2264,7 @@ declare module "stream" {
 declare module "util" {
     export interface InspectOptions {
         showHidden?: boolean;
-        depth?: number;
+        depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
     }
@@ -2263,7 +2275,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
@@ -2585,6 +2597,7 @@ declare module "module" {
         static _extensions: { [ext: string]: (m: Module, fileName: string) => any }
 
         constructor (filename: string);
+        _compile (m: Module, filename: string): string;
 
         id: string;
         parent: Module;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/typed-typings/env-node#readme",
   "devDependencies": {
-    "typescript": "^1.8.9"
+    "typescript": "^2.0.3"
   }
 }


### PR DESCRIPTION
Closes https://github.com/types/env-node/issues/40.