### PR TITLE
Separate inline Process.env type to interface

### DIFF
--- a/0.10/node.d.ts
+++ b/0.10/node.d.ts
@@ -198,6 +198,11 @@ declare namespace NodeJS {
 
   export interface ReadWriteStream extends ReadableStream, WritableStream { }
 
+  export interface Env {
+    PATH: string;
+    [key: string]: string;
+  }
+
   export interface Process extends EventEmitter {
     stdout: WritableStream;
     stderr: WritableStream;
@@ -211,10 +216,7 @@ declare namespace NodeJS {
     abort(): void;
     chdir(directory: string): void;
     cwd(): string;
-    env: {
-      PATH: string;
-      [key: string]: string;
-    };
+    env: Env;
     exit(code?: number): void;
     getgid(): number;
     setgid(id: number): void;

--- a/0.12/node.d.ts
+++ b/0.12/node.d.ts
@@ -300,6 +300,11 @@ declare namespace NodeJS {
 
   export interface ReadWriteStream extends ReadableStream, WritableStream { }
 
+  export interface Env {
+    PATH: string;
+    [key: string]: string;
+  }
+
   export interface Process extends EventEmitter {
     stdout: WritableStream;
     stderr: WritableStream;
@@ -313,10 +318,7 @@ declare namespace NodeJS {
     abort(): void;
     chdir(directory: string): void;
     cwd(): string;
-    env: {
-      PATH: string;
-      [key: string]: string;
-    };
+    env: Env;
     exit(code?: number): void;
     exitCode?: number;
     getgid(): number;

--- a/4.0/node.d.ts
+++ b/4.0/node.d.ts
@@ -478,6 +478,11 @@ declare namespace NodeJS {
     heapUsed: number;
   }
 
+  export interface Env {
+    PATH: string;
+    [key: string]: string;
+  }
+
   export interface Process extends EventEmitter {
     stdout: WritableStream;
     stderr: WritableStream;
@@ -491,10 +496,7 @@ declare namespace NodeJS {
     abort(): void;
     chdir(directory: string): void;
     cwd(): string;
-    env: {
-      PATH: string;
-      [key: string]: string;
-    };
+    env: Env;
     exit(code?: number): void;
     exitCode?: number;
     getgid(): number;

--- a/6.0/node.d.ts
+++ b/6.0/node.d.ts
@@ -504,6 +504,11 @@ declare namespace NodeJS {
     heapUsed: number;
   }
 
+  export interface Env {
+    PATH: string;
+    [key: string]: string;
+  }
+
   export interface Process extends EventEmitter {
     stdout: WritableStream;
     stderr: WritableStream;
@@ -518,10 +523,7 @@ declare namespace NodeJS {
     abort(): void;
     chdir(directory: string): void;
     cwd(): string;
-    env: {
-      PATH: string;
-      [key: string]: string;
-    };
+    env: Env;
     exit(code?: number): void;
     exitCode?: number;
     getgid(): number;


### PR DESCRIPTION
Allows external [interface merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) for declaring user property types on `env`.

#39
